### PR TITLE
Recommand Etalab app on DVF datasets

### DIFF
--- a/recommendations.yml
+++ b/recommendations.yml
@@ -44,3 +44,19 @@
       id: https://www.data.gouv.fr/fr/reuses/moteur-de-recherche-des-personnes-decedees-matchid/
       score: 50
       type: reuse
+
+#Recommand Etalab app on DVF datasets
+-
+  source: https://www.data.gouv.fr/fr/datasets/demandes-de-valeurs-foncieres/
+  recommendations:
+    -
+      id: https://www.data.gouv.fr/fr/reuses/explorateur-de-donnees-de-valeur-fonciere-dvf/
+      score: 50
+      type: reuse
+-
+  source: https://www.data.gouv.fr/fr/datasets/demandes-de-valeurs-foncieres-geolocalisees/
+  recommendations:
+    -
+      id: https://www.data.gouv.fr/fr/reuses/explorateur-de-donnees-de-valeur-fonciere-dvf/
+      score: 50
+      type: reuse      

--- a/recommendations.yml
+++ b/recommendations.yml
@@ -45,7 +45,7 @@
       score: 50
       type: reuse
 
-#Recommand Etalab app on DVF datasets
+# Recommend Etalab app on DVF datasets
 -
   source: https://www.data.gouv.fr/fr/datasets/demandes-de-valeurs-foncieres/
   recommendations:


### PR DESCRIPTION
I've noticed that on most case a discussion is needed to choose which reuse to recommend. Also it is frequent that the reuses are not referenced (https://annuaire-entreprises.data.gouv.fr/ for the Siren/Siret datasets for instance). I'll try to think of something to increase the number of reuses referenced.