### PR TITLE
fix: :lock: update pyyaml to 5.4.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 requests==2.24.0
-PyYAML==5.4.1
+PyYAML==6.0.0
 jsonschema==3.2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 requests==2.24.0
-PyYAML==5.3.1
+PyYAML==5.4.1
 jsonschema==3.2.0


### PR DESCRIPTION
Pyyaml v6 is avaible but 5.4.1 is required by udata-front

Close https://github.com/etalab/datagouvfr-recommendations-edito/pull/5